### PR TITLE
Be more explicit about failure and don't touch env as much

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0.0
+
+* Inherit all environment except for LC_TIME in call to locale
+* More explicitly handle UTF8-decoding
+* Fail on non-zero exitcodes from locale
+
 # 0.2.0.0
 
 * Switch to attoparsec to reduce dependency footprint

--- a/system-locale.cabal
+++ b/system-locale.cabal
@@ -1,5 +1,5 @@
 name:                system-locale
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            Get system locales
 description:         Get system locales in a format suitable for the time library
 homepage:            https://github.com/cocreature/system-locale
@@ -23,6 +23,7 @@ library
                      , process >= 1.2 && < 1.7
                      , time >= 1.5 && < 1.9
                      , text >= 1.2 && < 1.3
+                     , bytestring >= 0.10 && < 0.11
   ghc-options:         -Wall
   default-language:    Haskell2010
 

--- a/system-locale.cabal
+++ b/system-locale.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:     System.Locale.Read
   build-depends:       attoparsec >= 0.13 && < 0.14
                      , base >= 4.7 && < 5
-                     , process >= 1.2 && < 1.7
+                     , process >= 1.4.3.0 && < 1.7
                      , time >= 1.5 && < 1.9
                      , text >= 1.2 && < 1.3
                      , bytestring >= 0.10 && < 0.11


### PR DESCRIPTION
More complicated handling of environment is required since on e.g. NixOS the locale files are in a nonstandard place and locale needs to be told where via `LOCALE_ARCHIVE`.

Additionally I experienced some encoding-weirdness so I extended the exception-type to report encoding errors (and nonzero exit-codes from locale, while I was at it) and started explicitly calling a `ByteString -> Text`-Conversion (the encoding is bundled with `text`, reading from the process-handle as a `ByteString` first sadly adds a dependency on bytestring, which most seem to consider rather basic)