### PR TITLE
Update to work with newer GHC versions (tested with 9.8.4 and 9.10.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM haskell:9.10.1
+
+RUN apt-get update && apt-get -y --no-install-recommends install locales-all
+
+WORKDIR /opt/system-locale
+
+RUN cabal update
+
+# Add just the .cabal file to capture dependencies
+COPY ./system-locale.cabal /opt/system-locale/system-locale.cabal
+
+# Docker will cache this command as a layer, freeing us up to
+# modify source code without re-installing dependencies
+# (unless the .cabal file changes!)
+RUN cabal build --only-dependencies -j4
+
+# Add and Install Application Code
+COPY . /opt/system-locale
+RUN cabal test

--- a/system-locale.cabal
+++ b/system-locale.cabal
@@ -1,5 +1,5 @@
 name:                system-locale
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Get system locales
 description:         Get system locales in a format suitable for the time library
 homepage:            https://github.com/cocreature/system-locale
@@ -13,17 +13,21 @@ build-type:          Simple
 extra-source-files:  CHANGELOG.md
                      README.md
 cabal-version:       >=1.10
-tested-with:         GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.3
+tested-with:           GHC == 8.0.2
+                     , GHC == 8.2.2
+                     , GHC == 8.4.3
+                     , GHC == 9.8.4
+                     , GHC == 9.10.1
 
 library
   hs-source-dirs:      src
   exposed-modules:     System.Locale.Read
-  build-depends:       attoparsec >= 0.13 && < 0.14
+  build-depends:       attoparsec >= 0.13 && < 0.15
                      , base >= 4.9 && < 5
                      , process >= 1.4.3.0 && < 1.7
-                     , time >= 1.5 && < 1.9
-                     , text >= 1.2 && < 1.3
-                     , bytestring >= 0.10 && < 0.11
+                     , time >= 1.5 && < 2
+                     , text >= 1.2 && < 2.2
+                     , bytestring >= 0.10 && < 0.13
   ghc-options:         -Wall
   default-language:    Haskell2010
 


### PR DESCRIPTION
Updated to version 0.4.0.0: Relaxed dependency restrictions to work with newer GHC versions.

Run tests via `docker build .`